### PR TITLE
docs: add mention of branch options for choosing specific end states

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an example of putting together:
 * [Laminar](https://laminar.dev/)
 * [Chart.js](https://www.chartjs.org/), statically typed with [ScalablyTyped](https://scalablytyped.org/)
 
-If you don't want the project walkthrough in it's entirety, you can specify up to which stage of the guide to include by cloning a specific branch:
+If you don't want the project walkthrough in its entirety, you can specify up to which stage of the guide to include by cloning a specific branch:
 * [Vite](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/scalajs-vite-end-state)
 * [Vite + Laminar](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/laminar-end-state)
 * [Vite + Laminar + ScalablyTyped](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/scalablytyped-end-state)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This is an example of putting together:
 * [Laminar](https://laminar.dev/)
 * [Chart.js](https://www.chartjs.org/), statically typed with [ScalablyTyped](https://scalablytyped.org/)
 
+If you don't want the project walkthrough in it's entirety, you can specify up to which stage of the guide to include by cloning a specific branch:
+* [Vite](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/scalajs-vite-end-state)
+* [Vite + Laminar](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/laminar-end-state)
+* [Vite + Laminar + ScalablyTyped](https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/tree/scalablytyped-end-state)
+
 ## Install
 
 You need to explicitly install the following software:


### PR DESCRIPTION
I had been avoiding cloning this repository because I won't need Laminar and did not want to go through the labor of removing it, instead opting to go through the labor of manually coping the steps of Vite section only (with lots of time wasted debugging to get it to work)

I didn't know each end state of the guide stages had a corresponding branch until after another Scala user showed me. I think it would be helpful to future users of this template to make that clear.